### PR TITLE
fix(ci): ensure lables and pr body are properly escaped

### DIFF
--- a/.github/workflows/pr-request-report-labels.yml
+++ b/.github/workflows/pr-request-report-labels.yml
@@ -23,35 +23,36 @@ jobs:
     steps:
       - name: Validate report label
         id: validate
+        env:
+          LABELS_JSON: ${{ toJson(github.event.pull_request.labels) }}
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           set -euo pipefail
 
-          labels_json='${{ toJson(github.event.pull_request.labels) }}'
-
           echo "Current labels:"
-          echo "$labels_json" | jq -r '.[].name'
+          jq -rn 'env.LABELS_JSON | fromjson | .[].name'
 
-          include_count="$(jq '[.[] | select(.name == "report: include")] | length' <<< "$labels_json")"
-          exclude_count="$(jq '[.[] | select(.name == "report: exclude")] | length' <<< "$labels_json")"
-          highlight_count="$(jq '[.[] | select(.name == "report: highlight")] | length' <<< "$labels_json")"
+          include_count="$(jq -n '[env.LABELS_JSON | fromjson | .[] | select(.name == "report: include")] | length')"
+          exclude_count="$(jq -n '[env.LABELS_JSON | fromjson | .[] | select(.name == "report: exclude")] | length')"
+          highlight_count="$(jq -n '[env.LABELS_JSON | fromjson | .[] | select(.name == "report: highlight")] | length')"
 
           total_count=$((include_count + exclude_count + highlight_count))
 
           if [ "$total_count" -eq 0 ]; then
             echo "valid=false" >> "$GITHUB_OUTPUT"
-            echo "message=Missing report label. Set exactly one of: \`report: include\`, \`report: exclude\` OR \`report: highlight\`." >> "$GITHUB_OUTPUT"
+            echo 'message=Missing report label. Set exactly one of: `report: include`, `report: exclude` OR `report: highlight`.' >> "$GITHUB_OUTPUT"
           elif [ "$total_count" -gt 1 ]; then
             echo "valid=false" >> "$GITHUB_OUTPUT"
-            echo "message=Only one report label is allowed: \`report: include\`, \`report: exclude\` OR \`report: highlight\`." >> "$GITHUB_OUTPUT"
+            echo 'message=Only one report label is allowed: `report: include`, `report: exclude` OR `report: highlight`.' >> "$GITHUB_OUTPUT"
           fi
 
-          feature_flag_count="$(jq '[.[] | select(.name == "feature flag")] | length' <<< "$labels_json")"
+          feature_flag_count="$(jq -n '[env.LABELS_JSON | fromjson | .[] | select(.name == "feature flag")] | length')"
           if [ "$feature_flag_count" -gt 0 ]; then
-            pr_body='${{ toJson(github.event.pull_request.body) }}'
-            pr_feature_flag_key="$(jq -nr --arg body "$pr_body" 'try ($body | gsub("\r"; "") | capture("(?m)^feature-flag:\\s*`(?<flag>[^`]+)`$").flag) catch ""')"
+            pr_feature_flag_key="$(jq -nr 'try (env.PR_BODY | gsub("\r"; "") | capture("(?m)^feature-flag:\\s*`(?<flag>[^`]+)`$").flag) catch ""')"
+
             if [ -z "$pr_feature_flag_key" ]; then
               echo "valid=false" >> "$GITHUB_OUTPUT"
-              echo "message=PR body must contain the feature flag key in the format: \`feature-flag: \\\`<feature-flag-key>\\\`\`." >> "$GITHUB_OUTPUT"
+              echo 'message=PR body must contain the feature flag key in the format: `feature-flag: <feature-flag-key>`.' >> "$GITHUB_OUTPUT"
             else
               echo "valid=true" >> "$GITHUB_OUTPUT"
             fi


### PR DESCRIPTION
Test PR Label

Fix `pr-request-report-labels.yml` breaking on nexpected EOF while looking for matching "'"
